### PR TITLE
Fix prediction editing on dashboard by passing missing handler props

### DIFF
--- a/predictions-frontend/src/components/layout/ContentPane.jsx
+++ b/predictions-frontend/src/components/layout/ContentPane.jsx
@@ -339,6 +339,8 @@ export default function ContentPane({
                 awayPlayers: match.awayPlayers || [],
               })
             }
+            handleEditPrediction={handleEditPrediction}
+            handleFixtureSelect={handleFixtureSelect}
             navigateToSection={navigateToSection}
             toggleChipInfoModal={toggleChipInfoModal}
           />


### PR DESCRIPTION
The dashboard case in ContentPane was not passing handleEditPrediction and handleFixtureSelect to DashboardView, causing the edit flow to silently fail after closing the breakdown modal.

https://claude.ai/code/session_011D2NxgM1YoEP7WUqyvvv3F