### PR TITLE
Make PredictionsModal and all sub-components mobile responsive

### DIFF
--- a/predictions-frontend/src/components/predictions/modal/ChipSelector.jsx
+++ b/predictions-frontend/src/components/predictions/modal/ChipSelector.jsx
@@ -74,9 +74,9 @@ const getCheckIconStyles = (color) => {
   return styles[color] || styles.emerald;
 };
 
-export default function ChipSelector({ 
-  selectedChips, 
-  onToggleChip, 
+export default function ChipSelector({
+  selectedChips,
+  onToggleChip,
   toggleChipInfoModal,
   gameweek,
   maxChips = 2,
@@ -89,52 +89,50 @@ export default function ChipSelector({
 
   // Get match-scoped chips with availability info
   const matchChips = getMatchChips();
-  
+
   // Check if a chip is locked (cannot be removed)
   const isChipLocked = (chipId) => lockedChips.includes(chipId);
-  
+
   // Check if a MATCH-SCOPED chip with gameweek limit is already used
-  // (e.g., Double Down can only be used on one match per gameweek)
-  // Gameweek-scoped chips should NOT be blocked by this check
   const isGameweekLimitReached = (chipId) => {
     const chipInfo = getChipInfo(chipId);
     const isMatchScopedWithLimit = chipInfo?.scope === 'match' && chipInfo?.gameweekLimit;
-    
+
     if (!isMatchScopedWithLimit) {
-      return false; // Gameweek-scoped chips are never "limit reached"
+      return false;
     }
-    
+
     return isChipUsedInGameweek(chipId, gameweek, userPredictions, currentMatchId);
   };
 
   return (
-    <div className="mb-6">
-      <div className="flex items-center gap-3 mb-4">
-        <div className="w-10 h-10 rounded-xl bg-purple-500/20 flex items-center justify-center border border-purple-500/30">
-          <LightningBoltIcon className="w-5 h-5 text-purple-400" />
+    <div className="mb-4 sm:mb-6">
+      <div className="flex items-center gap-2 sm:gap-3 mb-3 sm:mb-4">
+        <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-lg sm:rounded-xl bg-purple-500/20 flex items-center justify-center border border-purple-500/30">
+          <LightningBoltIcon className="w-4 h-4 sm:w-5 sm:h-5 text-purple-400" />
         </div>
         <div className="flex items-center justify-between w-full">
           <h3
             className={`${
               theme === "dark" ? "text-slate-100" : "text-slate-900"
-            } text-xl font-bold font-outfit`}
+            } text-lg sm:text-xl font-bold font-outfit`}
           >
             Match Chips
           </h3>
-          <span className="text-purple-300 text-xs bg-purple-500/20 border border-purple-500/30 rounded-full px-3 py-1 font-medium">
+          <span className="text-purple-300 text-2xs sm:text-xs bg-purple-500/20 border border-purple-500/30 rounded-full px-2 sm:px-3 py-0.5 sm:py-1 font-medium">
             {selectedChips.length}/{maxChips}
           </span>
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 mb-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 sm:gap-3 mb-3 sm:mb-4">
         {matchChips.map((chip) => {
           const isSelected = selectedChips.includes(chip.id);
           const isLocked = isChipLocked(chip.id);
           const chipAvailable = chip.available;
           const gameweekLimitReached = !isSelected && !isLocked && isGameweekLimitReached(chip.id);
-          const isDisabled = (!isSelected && selectedChips.length >= maxChips) || 
-                            (!chipAvailable && !isLocked) || 
+          const isDisabled = (!isSelected && selectedChips.length >= maxChips) ||
+                            (!chipAvailable && !isLocked) ||
                             gameweekLimitReached;
           const cooldownDisplay = formatCooldownDisplay(chip);
           const seasonLimitDisplay = formatSeasonLimitDisplay(chip.id, chip.usageCount || 0);
@@ -144,9 +142,8 @@ export default function ChipSelector({
               key={chip.id}
               type="button"
               onClick={() => {
-                // Don't allow removing locked chips
                 if (isLocked && isSelected) {
-                  onToggleChip(chip.id); // This will show toast error
+                  onToggleChip(chip.id);
                   return;
                 }
                 if (chipAvailable || isSelected) {
@@ -156,7 +153,7 @@ export default function ChipSelector({
               disabled={isDisabled && !isSelected && !isLocked}
               whileHover={{ scale: isDisabled && !isSelected ? 1 : 1.02 }}
               whileTap={{ scale: 0.98 }}
-              className={`relative flex items-center rounded-xl border p-3 transition-all duration-200 ${
+              className={`relative flex items-center rounded-lg sm:rounded-xl border p-2.5 sm:p-3 transition-all duration-200 ${
                 isSelected
                   ? getSelectedStyles(chip.color)
                   : isDisabled
@@ -164,41 +161,41 @@ export default function ChipSelector({
                   : getDefaultStyles(theme)
               }`}
               title={
-                isLocked 
+                isLocked
                   ? 'This chip cannot be removed once applied'
                   : gameweekLimitReached
                   ? 'This chip has already been used in this gameweek'
-                  : !chipAvailable 
-                  ? chip.reason 
+                  : !chipAvailable
+                  ? chip.reason
                   : chip.description
               }
             >
               <div
-                className={`w-10 h-10 rounded-lg flex items-center justify-center mr-3 border ${getChipIconStyles(chip.color, isSelected, theme)}`}
+                className={`w-8 h-8 sm:w-10 sm:h-10 rounded-lg flex items-center justify-center mr-2 sm:mr-3 border flex-shrink-0 ${getChipIconStyles(chip.color, isSelected, theme)}`}
               >
                 {isLocked ? (
                   <div className="relative">
-                    <span className="text-lg opacity-50">{chip.icon}</span>
-                    <LockClosedIcon className="w-4 h-4 absolute -bottom-1 -right-1 text-amber-400" />
+                    <span className="text-base sm:text-lg opacity-50">{chip.icon}</span>
+                    <LockClosedIcon className="w-3 h-3 sm:w-4 sm:h-4 absolute -bottom-1 -right-1 text-amber-400" />
                   </div>
                 ) : !chipAvailable && !isSelected ? (
-                  <LockClosedIcon className="w-5 h-5" />
+                  <LockClosedIcon className="w-4 h-4 sm:w-5 sm:h-5" />
                 ) : (
-                  <span className="text-lg">{chip.icon}</span>
+                  <span className="text-base sm:text-lg">{chip.icon}</span>
                 )}
               </div>
 
-              <div className="flex-1 text-left">
-                <div className="flex items-center gap-1.5">
+              <div className="flex-1 text-left min-w-0">
+                <div className="flex items-center gap-1 sm:gap-1.5">
                   <div
-                    className={`text-sm font-medium transition-colors ${getChipTextStyles(chip.color, isSelected, theme)}`}
+                    className={`text-xs sm:text-sm font-medium transition-colors truncate ${getChipTextStyles(chip.color, isSelected, theme)}`}
                   >
                     {chip.name}
                   </div>
                   {isLocked && (
-                    <div className={`text-2xs px-1.5 py-0.5 rounded font-medium ${
-                      theme === 'dark' 
-                        ? 'bg-amber-900/30 text-amber-400 border border-amber-700/30' 
+                    <div className={`text-2xs px-1 sm:px-1.5 py-0.5 rounded font-medium flex-shrink-0 ${
+                      theme === 'dark'
+                        ? 'bg-amber-900/30 text-amber-400 border border-amber-700/30'
                         : 'bg-amber-100 text-amber-700 border border-amber-300'
                     }`}>
                       Locked
@@ -206,17 +203,17 @@ export default function ChipSelector({
                   )}
                 </div>
                 {!chipAvailable && !isSelected && !isLocked && !gameweekLimitReached && (
-                  <div className="text-xs text-red-400 mt-0.5">
+                  <div className="text-2xs sm:text-xs text-red-400 mt-0.5 truncate">
                     {cooldownDisplay || seasonLimitDisplay || 'Unavailable'}
                   </div>
                 )}
                 {gameweekLimitReached && !isSelected && !isLocked && (
-                  <div className="text-xs text-amber-400 mt-0.5">
+                  <div className="text-2xs sm:text-xs text-amber-400 mt-0.5 truncate">
                     Already used this gameweek
                   </div>
                 )}
                 {chipAvailable && seasonLimitDisplay && !isSelected && (
-                  <div className="text-xs text-slate-400 mt-0.5">
+                  <div className="text-2xs sm:text-xs text-slate-400 mt-0.5 truncate">
                     {seasonLimitDisplay}
                   </div>
                 )}
@@ -224,18 +221,18 @@ export default function ChipSelector({
 
               {isSelected && !isLocked && (
                 <div
-                  className={`w-6 h-6 rounded-full flex items-center justify-center ml-2 ${getCheckIconStyles(chip.color)}`}
+                  className={`w-5 h-5 sm:w-6 sm:h-6 rounded-full flex items-center justify-center ml-1.5 sm:ml-2 flex-shrink-0 ${getCheckIconStyles(chip.color)}`}
                 >
-                  <CheckIcon className="w-3 h-3" />
+                  <CheckIcon className="w-2.5 h-2.5 sm:w-3 sm:h-3" />
                 </div>
               )}
               {isSelected && isLocked && (
-                <div className={`w-6 h-6 rounded-full flex items-center justify-center ml-2 ${
+                <div className={`w-5 h-5 sm:w-6 sm:h-6 rounded-full flex items-center justify-center ml-1.5 sm:ml-2 flex-shrink-0 ${
                   theme === 'dark'
                     ? 'bg-amber-500/20 border border-amber-500/30'
                     : 'bg-amber-200 border border-amber-300'
                 }`}>
-                  <LockClosedIcon className="w-3 h-3 text-amber-400" />
+                  <LockClosedIcon className="w-2.5 h-2.5 sm:w-3 sm:h-3 text-amber-400" />
                 </div>
               )}
             </motion.button>
@@ -253,9 +250,9 @@ export default function ChipSelector({
             theme === "dark"
               ? "text-purple-300 hover:text-purple-200"
               : "text-purple-600 hover:text-purple-700"
-          } text-sm flex items-center transition-colors font-medium`}
+          } text-xs sm:text-sm flex items-center transition-colors font-medium py-1`}
         >
-          <InfoCircledIcon className="mr-2 w-4 h-4" />
+          <InfoCircledIcon className="mr-1.5 sm:mr-2 w-3.5 h-3.5 sm:w-4 sm:h-4" />
           Learn more about all available chips
         </button>
       </div>

--- a/predictions-frontend/src/components/predictions/modal/ChipsSummary.jsx
+++ b/predictions-frontend/src/components/predictions/modal/ChipsSummary.jsx
@@ -24,15 +24,15 @@ export default function ChipsSummary({ selectedChips }) {
       className={`${getThemeStyles(theme, {
         dark: "bg-slate-800/50 border-slate-700/60",
         light: "bg-slate-50/50 border-slate-200/60",
-      })} border rounded-xl p-4 mb-4 font-outfit`}
+      })} border rounded-lg sm:rounded-xl p-3 sm:p-4 mb-3 sm:mb-4 font-outfit`}
     >
       <h4
         className={`${getThemeStyles(theme, {
           dark: "text-slate-200",
           light: "text-slate-800",
-        })} text-sm font-medium mb-3 flex items-center`}
+        })} text-xs sm:text-sm font-medium mb-2 sm:mb-3 flex items-center`}
       >
-        <LightningBoltIcon className="mr-2 w-4 h-4 text-purple-400" />
+        <LightningBoltIcon className="mr-1.5 sm:mr-2 w-3.5 h-3.5 sm:w-4 sm:h-4 text-purple-400" />
         Selected Match Chips
       </h4>
 
@@ -41,7 +41,7 @@ export default function ChipsSummary({ selectedChips }) {
           className={`${getThemeStyles(theme, {
             dark: "text-slate-400 bg-slate-700/30",
             light: "text-slate-600 bg-slate-100/30",
-          })} text-sm py-2 px-3 rounded-lg text-center`}
+          })} text-xs sm:text-sm py-2 px-3 rounded-lg text-center`}
         >
           No chips selected for this match
         </div>
@@ -57,22 +57,22 @@ export default function ChipsSummary({ selectedChips }) {
                 className={`flex items-center ${getThemeStyles(theme, {
                   dark: "bg-slate-700/40",
                   light: "bg-slate-100/40",
-                })} border border-${chip.color}-500/20 rounded-lg px-3 py-2.5`}
+                })} border border-${chip.color}-500/20 rounded-lg px-2.5 sm:px-3 py-2 sm:py-2.5`}
               >
                 <div
-                  className={`w-8 h-8 rounded-lg flex items-center justify-center bg-${chip.color}-500/20 border border-${chip.color}-500/30 mr-3 text-lg`}
+                  className={`w-7 h-7 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center bg-${chip.color}-500/20 border border-${chip.color}-500/30 mr-2 sm:mr-3 text-base sm:text-lg`}
                 >
                   {chip.icon}
                 </div>
-                <div className="flex-1">
-                  <div className={`text-${chip.color}-300 text-sm font-medium`}>
+                <div className="flex-1 min-w-0">
+                  <div className={`text-${chip.color}-300 text-xs sm:text-sm font-medium`}>
                     {chip.name}
                   </div>
                   <div
                     className={`${getThemeStyles(theme, {
                       dark: "text-slate-400",
                       light: "text-slate-600",
-                    })} text-xs leading-relaxed`}
+                    })} text-2xs sm:text-xs leading-relaxed`}
                   >
                     {chip.description}
                   </div>

--- a/predictions-frontend/src/components/predictions/modal/GoalscorerSummary.jsx
+++ b/predictions-frontend/src/components/predictions/modal/GoalscorerSummary.jsx
@@ -19,19 +19,19 @@ export default function GoalscorerSummary({
       className={`${getThemeStyles(theme, {
         dark: "bg-slate-800/50 border-slate-700/60",
         light: "bg-slate-50/50 border-slate-200/60",
-      })} border rounded-xl p-4 mb-4 font-outfit`}
+      })} border rounded-lg sm:rounded-xl p-3 sm:p-4 mb-3 sm:mb-4 font-outfit`}
     >
       <h4
         className={`${getThemeStyles(theme, {
           dark: "text-slate-200",
           light: "text-slate-800",
-        })} text-sm font-medium mb-3 flex items-center`}
+        })} text-xs sm:text-sm font-medium mb-2 sm:mb-3 flex items-center`}
       >
-        <TargetIcon className="mr-2 w-4 h-4 text-emerald-400" />
+        <TargetIcon className="mr-1.5 sm:mr-2 w-3.5 h-3.5 sm:w-4 sm:h-4 text-emerald-400" />
         Predicted Goalscorers
       </h4>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
         {homeScore > 0 && (
           <div className="space-y-2">
             <div

--- a/predictions-frontend/src/components/predictions/modal/GoalscorersStep.jsx
+++ b/predictions-frontend/src/components/predictions/modal/GoalscorersStep.jsx
@@ -7,16 +7,16 @@ import ScoreDisplay from "./ScoreDisplay";
 import GoalscorerSelector from "./GoalscorerSelector";
 import ChipSelector from "./ChipSelector";
 
-export default function GoalscorersStep({ 
-  fixture, 
-  homeScore, 
-  awayScore, 
-  homeScorers, 
-  awayScorers, 
-  onHomeScorerChange, 
-  onAwayScorerChange, 
-  selectedChips, 
-  onToggleChip, 
+export default function GoalscorersStep({
+  fixture,
+  homeScore,
+  awayScore,
+  homeScorers,
+  awayScorers,
+  onHomeScorerChange,
+  onAwayScorerChange,
+  selectedChips,
+  onToggleChip,
   toggleChipInfoModal,
   gameweek,
   chipWarning,
@@ -36,35 +36,35 @@ export default function GoalscorersStep({
       transition={{ duration: 0.3 }}
     >
       {/* Score summary */}
-      <div className={`rounded-xl p-6 mb-6 ${getThemeStyles(theme, {
+      <div className={`rounded-lg sm:rounded-xl p-3 sm:p-4 md:p-6 mb-4 sm:mb-6 ${getThemeStyles(theme, {
         dark: 'bg-slate-800/50 border border-slate-700/60',
         light: 'bg-slate-50 border border-slate-200'
       })}`}>
-        <div className={`text-xs font-medium mb-3 font-outfit text-center ${getThemeStyles(theme, {
+        <div className={`text-2xs sm:text-xs font-medium mb-2 sm:mb-3 font-outfit text-center ${getThemeStyles(theme, {
           dark: 'text-slate-400',
           light: 'text-slate-600'
         })}`}>
           Your Predicted Score
         </div>
-        <ScoreDisplay 
-          fixture={fixture} 
-          homeScore={homeScore} 
-          awayScore={awayScore} 
-          variant="summary" 
+        <ScoreDisplay
+          fixture={fixture}
+          homeScore={homeScore}
+          awayScore={awayScore}
+          variant="summary"
         />
       </div>
 
       {/* Goalscorers section */}
-      <div className={`rounded-xl p-6 mb-6 ${getThemeStyles(theme, {
+      <div className={`rounded-lg sm:rounded-xl p-3 sm:p-4 md:p-6 mb-4 sm:mb-6 ${getThemeStyles(theme, {
         dark: 'bg-slate-800/50 border border-slate-700/60',
         light: 'bg-slate-50 border border-slate-200'
       })}`}>
-        <div className="flex items-center space-x-2 mb-4">
-          <TargetIcon className={`w-5 h-5 ${getThemeStyles(theme, {
+        <div className="flex items-center space-x-2 mb-3 sm:mb-4">
+          <TargetIcon className={`w-4 h-4 sm:w-5 sm:h-5 ${getThemeStyles(theme, {
             dark: 'text-blue-400',
             light: 'text-blue-600'
           })}`} />
-          <h3 className={`text-lg font-semibold font-outfit ${getThemeStyles(theme, {
+          <h3 className={`text-base sm:text-lg font-semibold font-outfit ${getThemeStyles(theme, {
             dark: 'text-slate-200',
             light: 'text-slate-800'
           })}`}>
@@ -73,8 +73,8 @@ export default function GoalscorersStep({
         </div>
 
         {homeScore > 0 || awayScore > 0 ? (
-          <div className="mt-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="mt-3 sm:mt-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
               {/* Home team scorers */}
               {homeScore > 0 && (
                 <GoalscorerSelector
@@ -104,16 +104,16 @@ export default function GoalscorersStep({
           </div>
         ) : (
           <div
-            className={`font-outfit rounded-xl py-4 px-5 text-center border border-dashed ${getThemeStyles(theme, {
+            className={`font-outfit rounded-lg sm:rounded-xl py-3 sm:py-4 px-4 sm:px-5 text-center border border-dashed ${getThemeStyles(theme, {
               dark: "border-slate-600/50 bg-slate-800/30",
               light: "border-slate-300/50 bg-slate-50/30",
-            })} flex flex-col items-center mt-4`}
+            })} flex flex-col items-center mt-3 sm:mt-4`}
           >
             <p
               className={`${getThemeStyles(theme, {
                 dark: "text-slate-200",
                 light: "text-slate-800",
-              })} text-md font-medium`}
+              })} text-sm sm:text-md font-medium`}
             >
               Scoreless draw predicted
             </p>
@@ -121,7 +121,7 @@ export default function GoalscorersStep({
               className={`${getThemeStyles(theme, {
                 dark: "text-slate-400",
                 light: "text-slate-600",
-              })} text-sm mt-1`}
+              })} text-xs sm:text-sm mt-1`}
             >
               No goalscorers needed
             </p>
@@ -145,20 +145,20 @@ export default function GoalscorersStep({
         <motion.div
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
-          className={`mt-4 rounded-xl p-4 border flex items-start gap-3 ${getThemeStyles(theme, {
+          className={`mt-3 sm:mt-4 rounded-lg sm:rounded-xl p-3 sm:p-4 border flex items-start gap-2 sm:gap-3 ${getThemeStyles(theme, {
             dark: 'bg-amber-500/10 border-amber-500/30',
             light: 'bg-amber-50 border-amber-300'
           })}`}
         >
-          <ExclamationTriangleIcon className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5" />
+          <ExclamationTriangleIcon className="w-4 h-4 sm:w-5 sm:h-5 text-amber-400 flex-shrink-0 mt-0.5" />
           <div className="flex-1">
-            <p className={`text-sm font-medium font-outfit ${getThemeStyles(theme, {
+            <p className={`text-xs sm:text-sm font-medium font-outfit ${getThemeStyles(theme, {
               dark: 'text-amber-300',
               light: 'text-amber-700'
             })}`}>
               Chip Availability Warning
             </p>
-            <p className={`text-xs mt-1 ${getThemeStyles(theme, {
+            <p className={`text-2xs sm:text-xs mt-1 ${getThemeStyles(theme, {
               dark: 'text-amber-200/80',
               light: 'text-amber-600'
             })}`}>

--- a/predictions-frontend/src/components/predictions/modal/ModalFooter.jsx
+++ b/predictions-frontend/src/components/predictions/modal/ModalFooter.jsx
@@ -3,12 +3,12 @@ import { motion } from "framer-motion";
 import { ThemeContext } from "../../../context/ThemeContext";
 import { ChevronRightIcon, CheckIcon } from "@radix-ui/react-icons";
 
-export default function ModalFooter({ 
-  currentStep, 
-  totalSteps = 3, 
-  onPrevStep, 
-  onNextStep, 
-  onSubmit, 
+export default function ModalFooter({
+  currentStep,
+  totalSteps = 3,
+  onPrevStep,
+  onNextStep,
+  onSubmit,
   submitting = false,
   disableNext = false
 }) {
@@ -20,7 +20,7 @@ export default function ModalFooter({
         theme === "dark"
           ? "border-slate-700/60 bg-slate-800/40"
           : "border-slate-200/60 bg-slate-50/40"
-      } p-4`}
+      } p-3 sm:p-4`}
     >
       <div className="flex justify-between items-center">
         <motion.button
@@ -28,7 +28,7 @@ export default function ModalFooter({
           onClick={onPrevStep}
           whileHover={{ scale: currentStep === 1 ? 1 : 1.02 }}
           whileTap={{ scale: currentStep === 1 ? 1 : 0.98 }}
-          className={`px-4 py-2.5 rounded-lg border text-sm font-medium transition-all duration-200 font-outfit ${
+          className={`px-3 sm:px-4 py-3 sm:py-2.5 rounded-lg border text-sm font-medium transition-all duration-200 font-outfit ${
             currentStep === 1
               ? "invisible"
               : theme === "dark"
@@ -44,7 +44,7 @@ export default function ModalFooter({
 
         {currentStep < totalSteps ? (
           disableNext ? (
-            <div className="invisible px-6 py-2.5">
+            <div className="invisible px-4 sm:px-6 py-3 sm:py-2.5">
               <div className="flex items-center">
                 Continue
                 <ChevronRightIcon className="w-4 h-4 ml-1" />
@@ -56,7 +56,7 @@ export default function ModalFooter({
               onClick={onNextStep}
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
-              className="px-6 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-all duration-200 text-sm font-medium font-outfit shadow-lg shadow-blue-600/25 hover:shadow-blue-600/40"
+              className="px-4 sm:px-6 py-3 sm:py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-all duration-200 text-sm font-medium font-outfit shadow-lg shadow-blue-600/25 hover:shadow-blue-600/40"
             >
               <div className="flex items-center">
                 Continue
@@ -71,7 +71,7 @@ export default function ModalFooter({
             disabled={submitting}
             whileHover={{ scale: submitting ? 1 : 1.02 }}
             whileTap={{ scale: submitting ? 1 : 0.98 }}
-            className={`px-6 py-2.5 rounded-lg transition-all duration-200 text-sm font-medium font-outfit flex items-center ${
+            className={`px-4 sm:px-6 py-3 sm:py-2.5 rounded-lg transition-all duration-200 text-sm font-medium font-outfit flex items-center ${
               submitting
                 ? "bg-purple-700/50 cursor-not-allowed text-purple-200"
                 : "bg-purple-600 hover:bg-purple-700 text-white shadow-lg shadow-purple-600/25 hover:shadow-purple-600/40"
@@ -80,12 +80,14 @@ export default function ModalFooter({
             {submitting ? (
               <>
                 <div className="w-4 h-4 border-2 border-purple-200/30 border-t-purple-200 rounded-full animate-spin mr-2"></div>
-                Submitting...
+                <span className="hidden sm:inline">Submitting...</span>
+                <span className="sm:hidden">Saving...</span>
               </>
             ) : (
               <>
-                <CheckIcon className="w-4 h-4 mr-2" />
-                Submit Prediction
+                <CheckIcon className="w-4 h-4 mr-1.5 sm:mr-2" />
+                <span className="hidden sm:inline">Submit Prediction</span>
+                <span className="sm:hidden">Submit</span>
               </>
             )}
           </motion.button>

--- a/predictions-frontend/src/components/predictions/modal/ModalHeader.jsx
+++ b/predictions-frontend/src/components/predictions/modal/ModalHeader.jsx
@@ -7,7 +7,7 @@ import { Cross2Icon, CalendarIcon, ClockIcon } from "@radix-ui/react-icons";
 
 export default function ModalHeader({ title, fixture, onClose, deadline }) {
   const { theme } = useContext(ThemeContext);
-  
+
   // Determine if editing based on title or use passed title
   const isEditing = title?.includes('Edit');
   const modalTitle = title || "Make Prediction";
@@ -16,7 +16,7 @@ export default function ModalHeader({ title, fixture, onClose, deadline }) {
   const deadlineTime = deadline?.timeLeft ? new Date(Date.now() + deadline.timeLeft) : addMinutes(matchDate, -30);
 
   return (
-    <div className={`p-6 border-b ${getThemeStyles(theme, {
+    <div className={`p-3 sm:p-4 md:p-6 border-b ${getThemeStyles(theme, {
       dark: 'border-slate-700/60',
       light: 'border-slate-200'
     })}`}>
@@ -25,46 +25,46 @@ export default function ModalHeader({ title, fixture, onClose, deadline }) {
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
         onClick={onClose}
-        className={`absolute top-4 right-4 p-2 rounded-lg transition-colors ${getThemeStyles(theme, {
+        className={`absolute top-2 right-2 sm:top-4 sm:right-4 p-2.5 sm:p-2 rounded-lg transition-colors z-10 ${getThemeStyles(theme, {
           dark: 'text-slate-400 hover:text-slate-200 hover:bg-slate-800/50',
           light: 'text-slate-500 hover:text-slate-700 hover:bg-slate-100'
         })}`}
         aria-label="Close"
       >
-        <Cross2Icon className="w-4 h-4" />
+        <Cross2Icon className="w-4 h-4 sm:w-4 sm:h-4" />
       </motion.button>
 
       {/* Rich Card Style Header */}
-      <div className={`rounded-xl p-6 ${getThemeStyles(theme, {
+      <div className={`rounded-lg sm:rounded-xl p-3 sm:p-4 md:p-6 ${getThemeStyles(theme, {
         dark: 'bg-slate-800/50 border border-slate-700/60',
         light: 'bg-slate-50 border border-slate-200'
       })}`}>
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center space-x-3">
-            <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${getThemeStyles(theme, {
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 sm:mb-4 gap-2 sm:gap-0">
+          <div className="flex items-center space-x-2 sm:space-x-3 min-w-0">
+            <div className={`w-7 h-7 sm:w-8 sm:h-8 rounded-lg flex-shrink-0 flex items-center justify-center ${getThemeStyles(theme, {
               dark: 'bg-blue-500/20',
               light: 'bg-blue-100'
             })}`}>
-              <CalendarIcon className={`w-4 h-4 ${getThemeStyles(theme, {
+              <CalendarIcon className={`w-3.5 h-3.5 sm:w-4 sm:h-4 ${getThemeStyles(theme, {
                 dark: 'text-blue-400',
                 light: 'text-blue-600'
               })}`} />
             </div>
-            <div>
-              <p className={`font-semibold font-outfit ${getThemeStyles(theme, text.primary)}`}>
+            <div className="min-w-0">
+              <p className={`text-sm sm:text-base font-semibold font-outfit truncate ${getThemeStyles(theme, text.primary)}`}>
                 {fixture.homeTeam} vs {fixture.awayTeam}
               </p>
-              <p className={`text-xs font-outfit ${getThemeStyles(theme, text.muted)}`}>
+              <p className={`text-2xs sm:text-xs font-outfit ${getThemeStyles(theme, text.muted)}`}>
                 GW{fixture.gameweek} • {formattedDate}
               </p>
             </div>
           </div>
-          
-          <div className="text-right">
-            <div className={`text-lg font-bold font-outfit ${getThemeStyles(theme, text.primary)}`}>
+
+          <div className="text-left sm:text-right ml-9 sm:ml-0 flex-shrink-0">
+            <div className={`text-sm sm:text-lg font-bold font-outfit ${getThemeStyles(theme, text.primary)}`}>
               {modalTitle}
             </div>
-            <div className={`text-xs font-medium font-outfit ${getThemeStyles(theme, {
+            <div className={`text-2xs sm:text-xs font-medium font-outfit ${getThemeStyles(theme, {
               dark: 'text-blue-400',
               light: 'text-blue-600'
             })}`}>
@@ -74,19 +74,19 @@ export default function ModalHeader({ title, fixture, onClose, deadline }) {
         </div>
 
         {/* Deadline Warning */}
-        <div className={`rounded-lg px-3 py-2 flex items-center ${getThemeStyles(theme, {
+        <div className={`rounded-lg px-2.5 sm:px-3 py-1.5 sm:py-2 flex items-center ${getThemeStyles(theme, {
           dark: 'bg-amber-500/10 border border-amber-500/20',
           light: 'bg-amber-50 border border-amber-200'
         })}`}>
-          <ClockIcon className={`mr-2 w-4 h-4 ${getThemeStyles(theme, {
+          <ClockIcon className={`mr-1.5 sm:mr-2 w-3.5 h-3.5 sm:w-4 sm:h-4 flex-shrink-0 ${getThemeStyles(theme, {
             dark: 'text-amber-400',
             light: 'text-amber-600'
           })}`} />
-          <span className={`text-xs font-outfit ${getThemeStyles(theme, {
+          <span className={`text-2xs sm:text-xs font-outfit ${getThemeStyles(theme, {
             dark: 'text-amber-300',
             light: 'text-amber-700'
           })}`}>
-            Prediction deadline: {format(deadlineTime, "MMM d, h:mm a")}
+            Deadline: {format(deadlineTime, "MMM d, h:mm a")}
           </span>
         </div>
       </div>

--- a/predictions-frontend/src/components/predictions/modal/PointsPotential.jsx
+++ b/predictions-frontend/src/components/predictions/modal/PointsPotential.jsx
@@ -76,15 +76,15 @@ export default function PointsPotential({
       className={`${getThemeStyles(theme, {
         dark: "bg-slate-800/50 border-slate-700/60",
         light: "bg-slate-50/50 border-slate-200/60",
-      })} border rounded-xl p-4 font-outfit`}
+      })} border rounded-lg sm:rounded-xl p-3 sm:p-4 font-outfit`}
     >
       <h4
         className={`${getThemeStyles(theme, {
           dark: "text-slate-200",
           light: "text-slate-800",
-        })} text-sm font-medium mb-4 flex items-center`}
+        })} text-xs sm:text-sm font-medium mb-3 sm:mb-4 flex items-center`}
       >
-        <StarIcon className="mr-2 w-4 h-4 text-amber-400" />
+        <StarIcon className="mr-1.5 sm:mr-2 w-3.5 h-3.5 sm:w-4 sm:h-4 text-amber-400" />
         Points Potential
       </h4>
 
@@ -267,7 +267,7 @@ export default function PointsPotential({
               className={`${getThemeStyles(theme, {
                 dark: "text-amber-400",
                 light: "text-amber-600",
-              })} font-bold text-xl`}
+              })} font-bold text-lg sm:text-xl`}
             >
               {calculateMaxPotential.total} pts
             </span>

--- a/predictions-frontend/src/components/predictions/modal/ReviewStep.jsx
+++ b/predictions-frontend/src/components/predictions/modal/ReviewStep.jsx
@@ -8,14 +8,14 @@ import GoalscorerSummary from "./GoalscorerSummary";
 import ChipsSummary from "./ChipsSummary";
 import PointsPotential from "./PointsPotential";
 
-export default function ReviewStep({ 
-  fixture, 
-  homeScore, 
-  awayScore, 
-  homeScorers, 
-  awayScorers, 
-  selectedChips, 
-  activeGameweekChips 
+export default function ReviewStep({
+  fixture,
+  homeScore,
+  awayScore,
+  homeScorers,
+  awayScorers,
+  selectedChips,
+  activeGameweekChips
 }) {
   const { theme } = useContext(ThemeContext);
 
@@ -26,15 +26,15 @@ export default function ReviewStep({
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.3 }}
-      className="pb-4"
+      className="pb-2 sm:pb-4"
     >
       <div className={`${getThemeStyles(theme, {
         dark: "bg-slate-800/50 border border-slate-700/60",
         light: "bg-slate-50/50 border border-slate-200/60",
-      })} rounded-xl p-6 mb-6`}>
-        <div className="flex items-center space-x-2 mb-4">
-          <CheckIcon className="w-5 h-5 text-purple-400" />
-          <h3 className={`text-lg font-semibold font-outfit ${getThemeStyles(theme, {
+      })} rounded-lg sm:rounded-xl p-3 sm:p-4 md:p-6 mb-4 sm:mb-6`}>
+        <div className="flex items-center space-x-2 mb-3 sm:mb-4">
+          <CheckIcon className="w-4 h-4 sm:w-5 sm:h-5 text-purple-400" />
+          <h3 className={`text-base sm:text-lg font-semibold font-outfit ${getThemeStyles(theme, {
             dark: "text-slate-200",
             light: "text-slate-800",
           })}`}>
@@ -46,18 +46,18 @@ export default function ReviewStep({
         <div className={`${getThemeStyles(theme, {
           dark: "bg-slate-900/50 border border-slate-700/30",
           light: "bg-slate-100/50 border border-slate-200/30",
-        })} rounded-lg p-4 mb-4`}>
-          <div className={`text-xs font-medium mb-3 font-outfit text-center ${getThemeStyles(theme, {
+        })} rounded-lg p-3 sm:p-4 mb-3 sm:mb-4`}>
+          <div className={`text-2xs sm:text-xs font-medium mb-2 sm:mb-3 font-outfit text-center ${getThemeStyles(theme, {
             dark: "text-slate-400",
             light: "text-slate-600",
           })}`}>
             Your Predicted Score
           </div>
-          <ScoreDisplay 
-            fixture={fixture} 
-            homeScore={homeScore} 
-            awayScore={awayScore} 
-            variant="review" 
+          <ScoreDisplay
+            fixture={fixture}
+            homeScore={homeScore}
+            awayScore={awayScore}
+            variant="review"
           />
         </div>
 
@@ -82,15 +82,15 @@ export default function ReviewStep({
           className={`${getThemeStyles(theme, {
             dark: "bg-slate-800/50 border-slate-700/60",
             light: "bg-slate-50/50 border-slate-200/60",
-          })} border rounded-xl p-4 mb-4 font-outfit`}
+          })} border rounded-lg sm:rounded-xl p-3 sm:p-4 mb-3 sm:mb-4 font-outfit`}
         >
           <h4
             className={`${getThemeStyles(theme, {
               dark: "text-slate-200",
               light: "text-slate-800",
-            })} text-sm font-medium mb-3 flex items-center`}
+            })} text-xs sm:text-sm font-medium mb-2 sm:mb-3 flex items-center`}
           >
-            <RocketIcon className="mr-2 w-4 h-4 text-blue-400" />
+            <RocketIcon className="mr-1.5 sm:mr-2 w-3.5 h-3.5 sm:w-4 sm:h-4 text-blue-400" />
             Active Gameweek Chips
           </h4>
 
@@ -100,14 +100,14 @@ export default function ReviewStep({
                 className={`flex items-center ${getThemeStyles(theme, {
                   dark: "bg-slate-700/40",
                   light: "bg-slate-100/40",
-                })} border border-blue-500/20 rounded-lg px-3 py-2.5`}
+                })} border border-blue-500/20 rounded-lg px-2.5 sm:px-3 py-2 sm:py-2.5`}
               >
-                <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-blue-500/20 border border-blue-500/30 mr-3 text-lg">
+                <div className="w-7 h-7 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center bg-blue-500/20 border border-blue-500/30 mr-2 sm:mr-3 text-base sm:text-lg">
                   🛡️
                 </div>
-                <div className="flex-1">
+                <div className="flex-1 min-w-0">
                   <div
-                    className={`text-sm font-medium ${getThemeStyles(theme, {
+                    className={`text-xs sm:text-sm font-medium ${getThemeStyles(theme, {
                       dark: "text-blue-300",
                       light: "text-blue-700",
                     })}`}
@@ -118,7 +118,7 @@ export default function ReviewStep({
                     className={`${getThemeStyles(theme, {
                       dark: "text-slate-400",
                       light: "text-slate-600",
-                    })} text-xs leading-relaxed`}
+                    })} text-2xs sm:text-xs leading-relaxed`}
                   >
                     Applied to all predictions this gameweek
                   </div>
@@ -131,20 +131,20 @@ export default function ReviewStep({
                 className={`flex items-center ${getThemeStyles(theme, {
                   dark: "bg-slate-700/40",
                   light: "bg-slate-100/40",
-                })} border border-red-500/20 rounded-lg px-3 py-2.5`}
+                })} border border-red-500/20 rounded-lg px-2.5 sm:px-3 py-2 sm:py-2.5`}
               >
-                <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-red-500/20 border border-red-500/30 mr-3 text-lg">
+                <div className="w-7 h-7 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center bg-red-500/20 border border-red-500/30 mr-2 sm:mr-3 text-base sm:text-lg">
                   🎯
                 </div>
-                <div className="flex-1">
-                  <div className="text-red-300 text-sm font-medium">
+                <div className="flex-1 min-w-0">
+                  <div className="text-red-300 text-xs sm:text-sm font-medium">
                     All-In Week
                   </div>
                   <div
                     className={`${getThemeStyles(theme, {
                       dark: "text-slate-400",
                       light: "text-slate-600",
-                    })} text-xs leading-relaxed`}
+                    })} text-2xs sm:text-xs leading-relaxed`}
                   >
                     All gameweek points doubled
                   </div>

--- a/predictions-frontend/src/components/predictions/modal/ScoreDisplay.jsx
+++ b/predictions-frontend/src/components/predictions/modal/ScoreDisplay.jsx
@@ -4,15 +4,15 @@ import { getThemeStyles } from "../../../utils/themeUtils";
 import TeamLogo from "../../ui/TeamLogo";
 import { LOGO_SIZES } from "../../../utils/teamLogos";
 
-export default function ScoreDisplay({ 
-  fixture, 
-  homeScore, 
-  awayScore, 
+export default function ScoreDisplay({
+  fixture,
+  homeScore,
+  awayScore,
   variant = "summary", // "summary", "review"
   className = ""
 }) {
   const { theme } = useContext(ThemeContext);
-  
+
   const getVariantStyles = () => {
     switch (variant) {
       case "review":
@@ -20,7 +20,7 @@ export default function ScoreDisplay({
           container: getThemeStyles(theme, {
             dark: "bg-purple-500/20 border border-purple-500/30",
             light: "bg-purple-100 border border-purple-200"
-          }) + " rounded-lg px-3",
+          }) + " rounded-lg px-2 sm:px-3",
           scoreBox: getThemeStyles(theme, {
             dark: "bg-slate-800/60",
             light: "bg-white/60"
@@ -39,7 +39,7 @@ export default function ScoreDisplay({
           container: getThemeStyles(theme, {
             dark: "bg-blue-500/20 border border-blue-500/30",
             light: "bg-blue-100 border border-blue-200"
-          }) + " rounded-lg px-3",
+          }) + " rounded-lg px-2 sm:px-3",
           scoreBox: getThemeStyles(theme, {
             dark: "bg-slate-800/60",
             light: "bg-white/60"
@@ -55,13 +55,13 @@ export default function ScoreDisplay({
         };
     }
   };
-  
+
   const styles = getVariantStyles();
 
   return (
     <div className={`flex justify-center items-center ${className}`}>
-      <div className="flex items-center">
-        <div className="mr-2">
+      <div className="flex items-center min-w-0">
+        <div className="mr-1.5 sm:mr-2 flex-shrink-0">
           <TeamLogo
             teamName={fixture.homeTeam}
             size={LOGO_SIZES.sm}
@@ -73,39 +73,39 @@ export default function ScoreDisplay({
           className={`${getThemeStyles(theme, {
             dark: "text-slate-200",
             light: "text-slate-800",
-          })} font-outfit text-sm mr-2 font-medium`}
+          })} font-outfit text-xs sm:text-sm mr-1.5 sm:mr-2 font-medium truncate max-w-[60px] sm:max-w-none`}
         >
           {fixture.homeTeam}
         </span>
       </div>
 
-      <div className={`flex items-center justify-center ${styles.container}`}>
-        <span className={`${styles.scoreBox} rounded-l-md py-2 px-4 text-2xl font-bold ${styles.homeColor}`}>
+      <div className={`flex items-center justify-center flex-shrink-0 ${styles.container}`}>
+        <span className={`${styles.scoreBox} rounded-l-md py-1.5 sm:py-2 px-3 sm:px-4 text-xl sm:text-2xl font-bold ${styles.homeColor}`}>
           {homeScore}
         </span>
         <span
-          className={`px-2 ${getThemeStyles(theme, {
+          className={`px-1.5 sm:px-2 ${getThemeStyles(theme, {
             dark: "text-slate-400",
             light: "text-slate-600",
           })}`}
         >
           -
         </span>
-        <span className={`${styles.scoreBox} rounded-r-md py-2 px-4 text-2xl font-bold ${styles.awayColor}`}>
+        <span className={`${styles.scoreBox} rounded-r-md py-1.5 sm:py-2 px-3 sm:px-4 text-xl sm:text-2xl font-bold ${styles.awayColor}`}>
           {awayScore}
         </span>
       </div>
 
-      <div className="flex items-center ml-3">
+      <div className="flex items-center ml-1.5 sm:ml-3 min-w-0">
         <span
           className={`${getThemeStyles(theme, {
             dark: "text-slate-200",
             light: "text-slate-800",
-          })} font-outfit text-sm mr-2 font-medium`}
+          })} font-outfit text-xs sm:text-sm mr-1.5 sm:mr-2 font-medium truncate max-w-[60px] sm:max-w-none`}
         >
           {fixture.awayTeam}
         </span>
-        <div className="ml-2">
+        <div className="ml-0 sm:ml-2 flex-shrink-0">
           <TeamLogo
             teamName={fixture.awayTeam}
             size={LOGO_SIZES.sm}

--- a/predictions-frontend/src/components/predictions/modal/ScorePredictionStep.jsx
+++ b/predictions-frontend/src/components/predictions/modal/ScorePredictionStep.jsx
@@ -4,11 +4,11 @@ import { ThemeContext } from "../../../context/ThemeContext";
 import { getThemeStyles, backgrounds, text } from "../../../utils/themeUtils";
 import { RocketIcon } from "@radix-ui/react-icons";
 
-export default function ScorePredictionStep({ 
-  fixture, 
-  homeScore, 
-  awayScore, 
-  onHomeScoreChange, 
+export default function ScorePredictionStep({
+  fixture,
+  homeScore,
+  awayScore,
+  onHomeScoreChange,
   onAwayScoreChange,
   disabled = false
 }) {
@@ -21,13 +21,13 @@ export default function ScorePredictionStep({
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, x: 20 }}
       transition={{ duration: 0.2 }}
-      className="pb-4"
+      className="pb-2 sm:pb-4"
     >
-      <div className="mb-6">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="w-10 h-10 rounded-xl bg-emerald-500/20 flex items-center justify-center border border-emerald-500/30">
+      <div className="mb-4 sm:mb-6">
+        <div className="flex items-center gap-2 sm:gap-3 mb-3 sm:mb-4">
+          <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-lg sm:rounded-xl bg-emerald-500/20 flex items-center justify-center border border-emerald-500/30">
             <RocketIcon
-              className={`w-5 h-5 ${getThemeStyles(theme, {
+              className={`w-4 h-4 sm:w-5 sm:h-5 ${getThemeStyles(theme, {
                 dark: "text-emerald-400",
                 light: "text-emerald-600",
               })}`}
@@ -37,37 +37,37 @@ export default function ScorePredictionStep({
             className={`${getThemeStyles(
               theme,
               text.primary
-            )} text-xl font-bold font-outfit`}
+            )} text-lg sm:text-xl font-bold font-outfit`}
           >
             Predict the scoreline
           </h3>
         </div>
 
         {/* Rich Card Style Score Prediction */}
-        <div className={`rounded-xl p-6 ${getThemeStyles(theme, {
+        <div className={`rounded-lg sm:rounded-xl p-3 sm:p-4 md:p-6 ${getThemeStyles(theme, {
           dark: 'bg-slate-800/50 border border-slate-700/60',
           light: 'bg-slate-50 border border-slate-200'
         })}`}>
           {/* Match Info Header */}
-          <div className={`text-xs font-medium mb-4 font-outfit ${getThemeStyles(theme, text.muted)}`}>
+          <div className={`text-2xs sm:text-xs font-medium mb-3 sm:mb-4 font-outfit ${getThemeStyles(theme, text.muted)}`}>
             Premier League • GW{fixture.gameweek} • {fixture.venue}
           </div>
 
           {/* Score Input Section */}
-          <div className={`rounded-lg p-6 ${getThemeStyles(theme, {
+          <div className={`rounded-lg p-3 sm:p-4 md:p-6 ${getThemeStyles(theme, {
             dark: 'bg-slate-900/50 border border-slate-700/30',
             light: 'bg-white border border-slate-200'
           })}`}>
-            <div className={`text-xs font-medium mb-4 font-outfit ${getThemeStyles(theme, text.muted)}`}>
+            <div className={`text-2xs sm:text-xs font-medium mb-3 sm:mb-4 font-outfit ${getThemeStyles(theme, text.muted)}`}>
               Enter Score Prediction
             </div>
-            
-            <div className="flex items-center justify-center space-x-8">
+
+            <div className="flex items-center justify-center space-x-4 sm:space-x-6 md:space-x-8">
               <div className="text-center flex-1">
-                <div className={`text-sm font-medium font-outfit mb-2 truncate ${getThemeStyles(theme, text.secondary)}`}>
+                <div className={`text-xs sm:text-sm font-medium font-outfit mb-2 truncate ${getThemeStyles(theme, text.secondary)}`}>
                   {fixture.homeTeam}
                 </div>
-                <div className="relative">
+                <div className="relative flex justify-center">
                   <input
                     type="number"
                     min="0"
@@ -83,8 +83,8 @@ export default function ScorePredictionStep({
                       );
                     }}
                     disabled={disabled}
-                    className={`appearance-none rounded-lg w-20 h-16 text-3xl text-center focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none font-outfit font-bold ${
-                      disabled 
+                    className={`appearance-none rounded-lg w-16 h-14 sm:w-20 sm:h-16 text-2xl sm:text-3xl text-center focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none font-outfit font-bold ${
+                      disabled
                         ? getThemeStyles(theme, {
                             dark: 'bg-slate-900/50 border border-slate-700/30 text-slate-600 cursor-not-allowed',
                             light: 'bg-slate-100 border border-slate-200 text-slate-400 cursor-not-allowed'
@@ -99,16 +99,16 @@ export default function ScorePredictionStep({
                   />
                 </div>
               </div>
-              
-              <div className={`text-lg font-bold font-outfit ${getThemeStyles(theme, text.muted)}`}>
+
+              <div className={`text-base sm:text-lg font-bold font-outfit ${getThemeStyles(theme, text.muted)}`}>
                 —
               </div>
-              
+
               <div className="text-center flex-1">
-                <div className={`text-sm font-medium font-outfit mb-2 truncate ${getThemeStyles(theme, text.secondary)}`}>
+                <div className={`text-xs sm:text-sm font-medium font-outfit mb-2 truncate ${getThemeStyles(theme, text.secondary)}`}>
                   {fixture.awayTeam}
                 </div>
-                <div className="relative">
+                <div className="relative flex justify-center">
                   <input
                     type="number"
                     min="0"
@@ -124,8 +124,8 @@ export default function ScorePredictionStep({
                       );
                     }}
                     disabled={disabled}
-                    className={`appearance-none rounded-lg w-20 h-16 text-3xl text-center focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none font-outfit font-bold ${
-                      disabled 
+                    className={`appearance-none rounded-lg w-16 h-14 sm:w-20 sm:h-16 text-2xl sm:text-3xl text-center focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none font-outfit font-bold ${
+                      disabled
                         ? getThemeStyles(theme, {
                             dark: 'bg-slate-900/50 border border-slate-700/30 text-slate-600 cursor-not-allowed',
                             light: 'bg-slate-100 border border-slate-200 text-slate-400 cursor-not-allowed'

--- a/predictions-frontend/src/components/predictions/modal/StepIndicator.jsx
+++ b/predictions-frontend/src/components/predictions/modal/StepIndicator.jsx
@@ -6,23 +6,23 @@ export default function StepIndicator({ currentStep }) {
   const { theme } = useContext(ThemeContext);
 
   const steps = [
-    { number: 1, title: "Score Prediction", color: "emerald" },
-    { number: 2, title: "Goalscorers & Chips", color: "blue" },
-    { number: 3, title: "Review & Submit", color: "purple" }
+    { number: 1, title: "Score Prediction", shortTitle: "Score", color: "emerald" },
+    { number: 2, title: "Goalscorers & Chips", shortTitle: "Scorers", color: "blue" },
+    { number: 3, title: "Review & Submit", shortTitle: "Review", color: "purple" }
   ];
 
   return (
-    <div className={`rounded-xl p-4 font-outfit ${getThemeStyles(theme, {
+    <div className={`rounded-lg sm:rounded-xl p-3 sm:p-4 font-outfit ${getThemeStyles(theme, {
       dark: 'bg-slate-800/50 border border-slate-700/60',
       light: 'bg-slate-50 border border-slate-200'
     })}`}>
       <div className="flex items-center justify-center">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1.5 sm:gap-3">
           {steps.map((step, index) => (
             <div key={step.number} className="flex items-center">
               <div className="flex items-center">
                 <div
-                  className={`w-8 h-8 rounded-lg flex items-center justify-center text-sm font-medium transition-all duration-200 ${
+                  className={`w-7 h-7 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center text-xs sm:text-sm font-medium transition-all duration-200 ${
                     currentStep >= step.number
                       ? step.color === "emerald"
                         ? "bg-emerald-500 text-white shadow-lg shadow-emerald-500/25"
@@ -38,7 +38,7 @@ export default function StepIndicator({ currentStep }) {
                   {step.number}
                 </div>
                 <div
-                  className={`text-sm ml-3 transition-colors ${
+                  className={`text-2xs sm:text-sm ml-1.5 sm:ml-3 transition-colors ${
                     currentStep === step.number
                       ? step.color === "emerald"
                         ? getThemeStyles(theme, {
@@ -57,14 +57,15 @@ export default function StepIndicator({ currentStep }) {
                       : getThemeStyles(theme, text.muted)
                   }`}
                 >
-                  {step.title}
+                  <span className="hidden sm:inline">{step.title}</span>
+                  <span className="sm:hidden">{step.shortTitle}</span>
                 </div>
               </div>
-              
+
               {index < steps.length - 1 && (
                 <div
-                  className={`w-12 h-0.5 rounded-full mx-3 transition-colors ${
-                    currentStep > step.number 
+                  className={`w-4 sm:w-12 h-0.5 rounded-full mx-1.5 sm:mx-3 transition-colors ${
+                    currentStep > step.number
                       ? step.color === "emerald"
                         ? "bg-emerald-500/70"
                         : step.color === "blue"


### PR DESCRIPTION
Apply consistent responsive breakpoints (sm:/md:) across all 11 modal sub-components following the app's existing mobileScaleUtils patterns:

- ModalHeader: stack layout on mobile, compact padding, larger close button touch target, truncate team names
- StepIndicator: short titles on mobile, smaller gaps/connectors
- ScorePredictionStep: reduced padding/spacing, smaller score inputs (w-16 h-14 vs w-20 h-16), tighter horizontal gaps
- GoalscorersStep: compact padding, responsive icon/text sizes
- ReviewStep: compact padding, responsive section headings/icons
- ModalFooter: taller buttons on mobile (py-3) for 44px touch targets, shorter labels ("Submit" vs "Submit Prediction")
- ScoreDisplay: truncate team names, smaller score boxes on mobile
- ChipSelector: single-column grid on mobile, smaller chip cards/icons
- ChipsSummary/GoalscorerSummary/PointsPotential: compact cards

https://claude.ai/code/session_011D2NxgM1YoEP7WUqyvvv3F