### PR TITLE
Add mobile sign out button and clickable StatusBar profile chip

### DIFF
--- a/predictions-frontend/src/components/dashboardRenders/SettingsView.jsx
+++ b/predictions-frontend/src/components/dashboardRenders/SettingsView.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useContext } from "react";
+import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { ThemeContext } from "../../context/ThemeContext";
+import { useAuth } from "../../context/AuthContext";
 import { useUserPreferences } from "../../context/UserPreferencesContext";
 import { text } from "../../utils/themeUtils";
 import { ToggleButton } from "../ui/buttons";
@@ -17,12 +19,15 @@ import {
   MixerHorizontalIcon,
   EnvelopeClosedIcon,
   PersonIcon,
+  ExitIcon,
 } from "@radix-ui/react-icons";
 import RulesAndPointsModal from "../common/RulesAndPointsModal";
 import ChipStrategyModal from "../predictions/ChipStrategyModal";
 
 const SettingsView = ({ navigateToSection }) => {
   const { theme, toggleTheme } = useContext(ThemeContext);
+  const { logout } = useAuth();
+  const navigate = useNavigate();
   const {
     preferences,
     updatePreference,
@@ -38,6 +43,16 @@ const SettingsView = ({ navigateToSection }) => {
   const showSuccessMessage = (message) => {
     setShowSuccess(message);
     setTimeout(() => setShowSuccess(""), 3000);
+  };
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+      navigate("/");
+    } catch (error) {
+      console.error("Logout error:", error);
+      navigate("/");
+    }
   };
 
   const handleResetPreferences = () => {
@@ -467,6 +482,25 @@ const SettingsView = ({ navigateToSection }) => {
           Reset All
         </motion.button>
       </motion.div>
+
+      {/* ═══ Sign Out ═══ */}
+      <div
+        className={`mt-2 pt-6 border-t ${
+          theme === "dark" ? "border-slate-700/30" : "border-slate-200/60"
+        }`}
+      >
+        <button
+          onClick={handleLogout}
+          className={`flex items-center gap-3 px-1 py-2 rounded-lg transition-colors font-outfit text-sm font-medium ${
+            theme === "dark"
+              ? "text-red-400 hover:text-red-300 hover:bg-red-500/10"
+              : "text-red-500 hover:text-red-600 hover:bg-red-50"
+          }`}
+        >
+          <ExitIcon className="w-4 h-4" />
+          <span>Sign Out</span>
+        </button>
+      </div>
 
       {/* Modals */}
       <RulesAndPointsModal

--- a/predictions-frontend/src/components/layout/StatusBarOption3.jsx
+++ b/predictions-frontend/src/components/layout/StatusBarOption3.jsx
@@ -16,12 +16,13 @@ import { useFixtures } from "../../hooks/useFixtures";
  * Shows: Next Match In + Points
  * Mobile-optimized layout with clear "Predict" button
  */
-export default function StatusBarOption3({ 
-  user, 
+export default function StatusBarOption3({
+  user,
   globalRank,
-  onMakePredictions, 
+  onMakePredictions,
+  onProfileClick,
   loading = false,
-  nextMatchData = null 
+  nextMatchData = null
 }) {
   const { theme, toggleTheme } = useContext(ThemeContext);
   const { fixtures } = useFixtures({ fallbackToSample: false });
@@ -87,11 +88,12 @@ export default function StatusBarOption3({
       <Box className="container mx-auto px-3 py-2 lg:py-4">
         <div className="flex items-center justify-between gap-3 lg:gap-6">
           {/* Left: Profile Chip */}
-          <div
-            className={`flex items-center gap-2 px-2.5 py-1 lg:px-3 lg:py-1.5 rounded-full flex-shrink-0 ${
+          <button
+            onClick={onProfileClick}
+            className={`flex items-center gap-2 px-2.5 py-1 lg:px-3 lg:py-1.5 rounded-full flex-shrink-0 transition-colors ${
               theme === "dark"
-                ? "bg-slate-800/50 border border-slate-700/50"
-                : "bg-white border border-slate-200"
+                ? "bg-slate-800/50 border border-slate-700/50 hover:bg-slate-700/60"
+                : "bg-white border border-slate-200 hover:bg-slate-50"
             }`}
           >
             {loading ? (
@@ -113,7 +115,7 @@ export default function StatusBarOption3({
                 </span>
               </>
             )}
-          </div>
+          </button>
 
           {/* Center: Stats Bar */}
           <div className="flex items-center gap-3 lg:gap-6 flex-1 justify-center">

--- a/predictions-frontend/src/pages/Home.jsx
+++ b/predictions-frontend/src/pages/Home.jsx
@@ -164,6 +164,7 @@ export default function Home() {
             nextMatchData={statusBarData.nextMatchData}
             loading={statusBarLoading}
             onMakePredictions={() => navigateToSection("fixtures")}
+            onProfileClick={() => navigateToSection("profile")}
           />
           {/* Breadcrumb & Search Bar */}
           <div


### PR DESCRIPTION
- Add "Sign Out" button at bottom of Settings page (accessible via mobile BottomTabBar)
- Make StatusBar username/avatar chip clickable to navigate to profile page
- Wire onProfileClick prop through Home.jsx → StatusBarOption3

https://claude.ai/code/session_011D2NxgM1YoEP7WUqyvvv3F