### PR TITLE
Add tab navigation to LeagueDetailView and redesign TabNavigation com…

### DIFF
--- a/predictions-frontend/src/components/dashboardRenders/LeagueDetailView.jsx
+++ b/predictions-frontend/src/components/dashboardRenders/LeagueDetailView.jsx
@@ -26,6 +26,7 @@ import { text } from "../../utils/themeUtils";
 import { spacing, padding } from "../../utils/mobileScaleUtils";
 import leagueAPI from "../../services/api/leagueAPI";
 import ViewToggleBarHybrid from "../ui/ViewToggleBarHybrid";
+import TabNavigation from "../ui/TabNavigation";
 import LeaguePredictionContentView from "../predictions/LeaguePredictionContentView";
 import LeaguePredictionFilters from "../predictions/LeaguePredictionFilters";
 
@@ -37,6 +38,12 @@ const leagueViews = [
   { id: "calendar", icon: CalendarIcon, label: "Calendar", description: "Monthly calendar view" },
   { id: "table", icon: TableIcon, label: "Table View", description: "Detailed table format" },
   { id: "carousel", icon: LayoutIcon, label: "Carousel", description: "Horizontal scrolling" },
+];
+
+// League detail tab options
+const leagueTabs = [
+  { id: "leaderboard", label: "Leaderboard", icon: TargetIcon },
+  { id: "predictions", label: "Predictions", icon: StackIcon },
 ];
 
 // ─── Container Card helper classes ──────────────────────────
@@ -56,6 +63,7 @@ const containerHeader = (theme) =>
 
 const LeagueDetailView = ({ leagueId, league, onBack, onManage, essentialData }) => {
   const { theme } = useContext(ThemeContext);
+  const [activeTab, setActiveTab] = useState("leaderboard");
 
   if (!league) {
     return (
@@ -241,11 +249,20 @@ const LeagueDetailView = ({ leagueId, league, onBack, onManage, essentialData })
         </div>
       </motion.div>
 
-      {/* Leaderboard Section */}
-      <LeaderboardSection leagueId={leagueId} formatSafeDate={formatSafeDate} />
+      {/* Tab Navigation */}
+      <TabNavigation
+        tabs={leagueTabs}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+      />
 
-      {/* Predictions Section */}
-      <PredictionsSection leagueId={leagueId} essentialData={essentialData} />
+      {/* Tab Content */}
+      {activeTab === "leaderboard" && (
+        <LeaderboardSection leagueId={leagueId} formatSafeDate={formatSafeDate} />
+      )}
+      {activeTab === "predictions" && (
+        <PredictionsSection leagueId={leagueId} essentialData={essentialData} />
+      )}
     </motion.div>
   );
 };
@@ -286,16 +303,6 @@ const LeaderboardSection = ({ leagueId, formatSafeDate }) => {
   if (loading) {
     return (
       <div className={containerCard(theme)}>
-        <div className={containerHeader(theme)}>
-          <div className="flex items-center gap-3">
-            <div className={`p-2 rounded-lg ${theme === "dark" ? "bg-teal-500/10 text-teal-400" : "bg-teal-50 text-teal-600"}`}>
-              <TargetIcon className="w-4 h-4 sm:w-5 sm:h-5" />
-            </div>
-            <h3 className={`${text.primary[theme]} font-outfit font-semibold text-base sm:text-lg`}>
-              Leaderboard
-            </h3>
-          </div>
-        </div>
         <div className="flex justify-center py-12">
           <div className={`w-8 h-8 border-2 ${theme === 'dark' ? 'border-teal-400' : 'border-teal-600'} border-t-transparent rounded-full animate-spin`}></div>
         </div>
@@ -306,16 +313,6 @@ const LeaderboardSection = ({ leagueId, formatSafeDate }) => {
   if (error) {
     return (
       <div className={containerCard(theme)}>
-        <div className={containerHeader(theme)}>
-          <div className="flex items-center gap-3">
-            <div className={`p-2 rounded-lg ${theme === "dark" ? "bg-teal-500/10 text-teal-400" : "bg-teal-50 text-teal-600"}`}>
-              <TargetIcon className="w-4 h-4 sm:w-5 sm:h-5" />
-            </div>
-            <h3 className={`${text.primary[theme]} font-outfit font-semibold text-base sm:text-lg`}>
-              Leaderboard
-            </h3>
-          </div>
-        </div>
         <div className="text-center py-12 px-5">
           <ExclamationTriangleIcon className="w-12 h-12 mx-auto mb-2 text-red-500" />
           <p className="font-outfit text-red-500">Failed to load standings</p>
@@ -326,26 +323,16 @@ const LeaderboardSection = ({ leagueId, formatSafeDate }) => {
 
   return (
     <div className={containerCard(theme)}>
-      {/* Header subsection */}
-      <div className={containerHeader(theme)}>
-        <div className="flex items-center gap-3">
-          <div className={`p-2 rounded-lg ${theme === "dark" ? "bg-teal-500/10 text-teal-400" : "bg-teal-50 text-teal-600"}`}>
-            <TargetIcon className="w-4 h-4 sm:w-5 sm:h-5" />
-          </div>
-          <div>
-            <h3 className={`${text.primary[theme]} font-outfit font-semibold text-base sm:text-lg`}>
-              Leaderboard
-            </h3>
-            <p className={`${text.secondary[theme]} text-xs sm:text-sm mt-0.5 font-outfit`}>
-              {standings.length > 0 ? `${standings.length} members competing` : "No rankings yet"}
-            </p>
-          </div>
-        </div>
-      </div>
-
       {/* Content */}
       {standings.length > 0 ? (
         <>
+          {/* Info bar */}
+          <div className={`${padding.cardCompact} border-b ${theme === "dark" ? "border-slate-700/30" : "border-slate-200"}`}>
+            <p className={`${text.muted[theme]} text-xs sm:text-sm font-outfit`}>
+              {standings.length} {standings.length === 1 ? "member" : "members"} competing
+            </p>
+          </div>
+
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
@@ -567,39 +554,11 @@ const PredictionsSection = ({ leagueId, essentialData }) => {
     // Could open a detailed modal here if needed
   };
 
-  // Hero header (shared by loading, error, and main states)
-  const heroHeader = (
-    <div className="flex flex-row justify-between items-center gap-3 mb-4 sm:mb-6">
-      <div>
-        <h2
-          className={`${
-            theme === "dark" ? "text-teal-100" : "text-teal-700"
-          } text-xl sm:text-2xl font-bold font-dmSerif mb-0.5`}
-        >
-          League Predictions
-        </h2>
-        <p className={`${text.secondary[theme]} font-outfit text-xs sm:text-sm opacity-70`}>
-          View and compare member predictions
-        </p>
-      </div>
-      {!loading && !error && (
-        <ViewToggleBarHybrid
-          viewMode={selectedViewMode}
-          setViewMode={handleViewModeChange}
-          views={leagueViews}
-        />
-      )}
-    </div>
-  );
-
   if (loading) {
     return (
-      <div>
-        {heroHeader}
-        <div className={containerCard(theme)}>
-          <div className="flex justify-center py-12">
-            <div className={`w-8 h-8 border-2 ${theme === 'dark' ? 'border-teal-400' : 'border-teal-600'} border-t-transparent rounded-full animate-spin`}></div>
-          </div>
+      <div className={containerCard(theme)}>
+        <div className="flex justify-center py-12">
+          <div className={`w-8 h-8 border-2 ${theme === 'dark' ? 'border-teal-400' : 'border-teal-600'} border-t-transparent rounded-full animate-spin`}></div>
         </div>
       </div>
     );
@@ -607,13 +566,10 @@ const PredictionsSection = ({ leagueId, essentialData }) => {
 
   if (error) {
     return (
-      <div>
-        {heroHeader}
-        <div className={containerCard(theme)}>
-          <div className="text-center py-12 px-5">
-            <ExclamationTriangleIcon className="w-12 h-12 mx-auto mb-2 text-red-500" />
-            <p className="font-outfit text-red-500">Failed to load predictions</p>
-          </div>
+      <div className={containerCard(theme)}>
+        <div className="text-center py-12 px-5">
+          <ExclamationTriangleIcon className="w-12 h-12 mx-auto mb-2 text-red-500" />
+          <p className="font-outfit text-red-500">Failed to load predictions</p>
         </div>
       </div>
     );
@@ -621,8 +577,14 @@ const PredictionsSection = ({ leagueId, essentialData }) => {
 
   return (
     <div>
-      {/* Hero-style header row */}
-      {heroHeader}
+      {/* View toggle row */}
+      <div className="flex justify-end mb-3 sm:mb-4">
+        <ViewToggleBarHybrid
+          viewMode={selectedViewMode}
+          setViewMode={handleViewModeChange}
+          views={leagueViews}
+        />
+      </div>
 
       {/* Container card with filters + content */}
       <div className={containerCard(theme)}>

--- a/predictions-frontend/src/components/ui/TabNavigation.jsx
+++ b/predictions-frontend/src/components/ui/TabNavigation.jsx
@@ -1,32 +1,54 @@
-import React, { useContext } from 'react';
-import { motion } from 'framer-motion';
-import { ThemeContext } from '../../context/ThemeContext';
+import React, { useContext } from "react";
+import { motion } from "framer-motion";
+import { ThemeContext } from "../../context/ThemeContext";
 
 const TabNavigation = ({ tabs, activeTab, setActiveTab }) => {
   const { theme } = useContext(ThemeContext);
-  
+
+  // Normalize tabs: accept either strings or {id, label, icon?} objects
+  const normalizedTabs = tabs.map((tab) =>
+    typeof tab === "string" ? { id: tab, label: tab.charAt(0).toUpperCase() + tab.slice(1) } : tab
+  );
+
   return (
-    <div className={`flex border-b ${theme === 'dark' ? 'border-slate-600/30' : 'border-slate-200'} mb-6`}>
-      {tabs.map((tab) => (
-        <button
-          key={tab}
-          onClick={() => setActiveTab(tab)}
-          className={`py-2 px-4 font-medium text-sm relative ${
-            activeTab === tab 
-              ? theme === 'dark' ? "text-teal-200" : "text-teal-600" 
-              : theme === 'dark' ? "text-white/60 hover:text-white/90" : "text-slate-500 hover:text-slate-900"
-          }`}
-        >
-          {tab.charAt(0).toUpperCase() + tab.slice(1)}
-          
-          {activeTab === tab && (
-            <motion.div 
-              className={`absolute bottom-0 left-0 right-0 h-0.5 ${theme === 'dark' ? 'bg-teal-500' : 'bg-teal-600'}`}
-              layoutId="tabIndicator"
-            />
-          )}
-        </button>
-      ))}
+    <div
+      className={`${
+        theme === "dark"
+          ? "bg-slate-800/40 border-slate-700/50"
+          : "bg-white border-slate-200 shadow-sm"
+      } backdrop-blur-sm rounded-xl p-1 border inline-flex`}
+    >
+      <div className="flex overflow-x-auto scrollbar-hide">
+        {normalizedTabs.map((tab) => {
+          const isActive = activeTab === tab.id;
+          const Icon = tab.icon;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`relative flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium font-outfit transition-all duration-200 flex-shrink-0 ${
+                isActive
+                  ? "text-white shadow-lg"
+                  : theme === "dark"
+                  ? "text-slate-300 hover:text-white hover:bg-slate-700/50"
+                  : "text-slate-600 hover:text-slate-800 hover:bg-slate-100"
+              }`}
+            >
+              {isActive && (
+                <motion.div
+                  layoutId="activeTabBg"
+                  className="absolute inset-0 bg-teal-600 rounded-lg"
+                  transition={{ type: "spring", bounce: 0.2, duration: 0.5 }}
+                />
+              )}
+              <span className="relative flex items-center gap-2">
+                {Icon && <Icon className="w-4 h-4" />}
+                {tab.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
…ponent

- Redesign TabNavigation: pill/segmented-control style with glassmorphism container, animated active indicator via framer-motion layoutId, support for both string arrays and {id, label, icon?} objects
- Add tab navigation to LeagueDetailView switching between Leaderboard and Predictions tabs, replacing vertical stacking of both sections
- Simplify LeaderboardSection: remove header subsection from container card, add subtle info bar ("X members competing"), table starts directly
- Simplify PredictionsSection: remove hero header, place ViewToggleBarHybrid in a standalone row above the container card

https://claude.ai/code/session_01Q5mipbpRiJNWo7sFEHch87