### PR TITLE
Move view selector into filter headers and remove Normal/Compact toggle

### DIFF
--- a/predictions-frontend/src/components/dashboardRenders/FixturesView.jsx
+++ b/predictions-frontend/src/components/dashboardRenders/FixturesView.jsx
@@ -1,11 +1,6 @@
 import React, { useState, useContext, useMemo } from "react";
 import { motion } from "framer-motion";
 import GameweekChipsPanel from "../panels/GameweekChipsPanel";
-import ViewToggleBar from "../ui/ViewToggleBar";
-import ViewToggleBarOption1 from "../ui/ViewToggleBarOption1";
-import ViewToggleBarOption2 from "../ui/ViewToggleBarOption2";
-import ViewToggleBarOption3 from "../ui/ViewToggleBarOption3";
-import ViewToggleBarHybrid from "../ui/ViewToggleBarHybrid";
 import ContentView from "../fixtures/ContentView";
 import FixtureFilters from "../fixtures/FixtureFilters";
 import { ThemeContext } from "../../context/ThemeContext";
@@ -288,14 +283,6 @@ const FixturesView = ({ handleFixtureSelect, toggleChipInfoModal }) => {
             View and predict upcoming fixtures
           </p>
         </div>
-
-        {/* View toggle controls - HYBRID: Bottom Sheet (mobile) + Dropdown (desktop) */}
-        <ViewToggleBarHybrid viewMode={viewMode} setViewMode={handleViewModeChange} />
-        
-        {/* TESTING OTHER OPTIONS (uncomment to test individually): */}
-        {/* <ViewToggleBarOption1 viewMode={viewMode} setViewMode={handleViewModeChange} /> */}
-        {/* <ViewToggleBarOption2 viewMode={viewMode} setViewMode={handleViewModeChange} /> */}
-        {/* <ViewToggleBarOption3 viewMode={viewMode} setViewMode={handleViewModeChange} /> */}
       </div>
       {/* CHIP STRATEGY SECTION - Elevated card with shadow */}
       <motion.div
@@ -380,6 +367,8 @@ const FixturesView = ({ handleFixtureSelect, toggleChipInfoModal }) => {
             filterTeam={filterTeam}
             setFilterTeam={setFilterTeam}
             fixtures={enhancedFixtures || []}
+            viewMode={viewMode}
+            setViewMode={handleViewModeChange}
           />
         </div>
 

--- a/predictions-frontend/src/components/dashboardRenders/LeagueDetailView.jsx
+++ b/predictions-frontend/src/components/dashboardRenders/LeagueDetailView.jsx
@@ -25,7 +25,6 @@ import { useUserPreferences } from "../../context/UserPreferencesContext";
 import { text } from "../../utils/themeUtils";
 import { spacing, padding } from "../../utils/mobileScaleUtils";
 import leagueAPI from "../../services/api/leagueAPI";
-import ViewToggleBarHybrid from "../ui/ViewToggleBarHybrid";
 import TabNavigation from "../ui/TabNavigation";
 import LeaguePredictionContentView from "../predictions/LeaguePredictionContentView";
 import LeaguePredictionFilters from "../predictions/LeaguePredictionFilters";
@@ -477,7 +476,6 @@ const PredictionsSection = ({ leagueId, essentialData }) => {
   const [selectedViewMode, setSelectedViewMode] = useState(
     preferences?.defaultLeaguePredictionsView || 'teams'
   );
-  const [cardStyle, setCardStyle] = useState(preferences?.cardStyle || 'normal');
 
   // Filter states
   const [activeFilter, setActiveFilter] = useState("all");
@@ -577,15 +575,6 @@ const PredictionsSection = ({ leagueId, essentialData }) => {
 
   return (
     <div>
-      {/* View toggle row */}
-      <div className="flex justify-end mb-3 sm:mb-4">
-        <ViewToggleBarHybrid
-          viewMode={selectedViewMode}
-          setViewMode={handleViewModeChange}
-          views={leagueViews}
-        />
-      </div>
-
       {/* Container card with filters + content */}
       <div className={containerCard(theme)}>
         {/* Filters subsection - de-emphasized */}
@@ -603,8 +592,9 @@ const PredictionsSection = ({ leagueId, essentialData }) => {
             setSortBy={setSortBy}
             showFilters={showFilters}
             setShowFilters={setShowFilters}
-            cardStyle={cardStyle}
-            setCardStyle={setCardStyle}
+            viewMode={selectedViewMode}
+            setViewMode={handleViewModeChange}
+            views={leagueViews}
             predictions={predictions}
             currentGameweek={currentGameweek}
           />
@@ -633,7 +623,6 @@ const PredictionsSection = ({ leagueId, essentialData }) => {
               currentGameweek={currentGameweek}
               onPredictionSelect={handlePredictionSelect}
               searchQuery={searchQuery}
-              cardStyle={cardStyle}
             />
           )}
         </div>

--- a/predictions-frontend/src/components/dashboardRenders/PredictionsView.jsx
+++ b/predictions-frontend/src/components/dashboardRenders/PredictionsView.jsx
@@ -3,7 +3,6 @@ import PredictionFilters from "../predictions/PredictionFilters";
 import PotentialPointsSummary from "../panels/PotentialPointsSummary";
 import PredictionContentView from "../predictions/PredictionContentView";
 import PredictionBreakdownModal from "../predictions/PredictionBreakdownModal";
-import ViewToggleBarHybrid from "../ui/ViewToggleBarHybrid";
 import EmptyPredictionState from "../predictions/EmptyPredictionState";
 import ChipSyncBanner from "../ui/ChipSyncBanner";
 import { ThemeContext } from "../../context/ThemeContext";
@@ -67,7 +66,6 @@ const PredictionsView = ({ handleEditPrediction }) => {
   });
   
   const [viewMode, setViewMode] = useState(preferences.defaultPredictionsView);
-  const [cardStyle, setCardStyle] = useState(preferences.cardStyle);
   const [selectedPrediction, setSelectedPrediction] = useState(null);
 
   // Wrapper function to update both state and preferences
@@ -262,9 +260,6 @@ const PredictionsView = ({ handleEditPrediction }) => {
             View and manage your predictions
           </p>
         </div>
-
-        {/* View toggle controls - HYBRID: Bottom Sheet (mobile) + Dropdown (desktop) */}
-        <ViewToggleBarHybrid viewMode={viewMode} setViewMode={handleViewModeChange} />
       </div>
       
       {/* POTENTIAL POINTS SUMMARY PANEL - Elevated card with shadow */}
@@ -335,8 +330,8 @@ const PredictionsView = ({ handleEditPrediction }) => {
           setSortBy={setSortBy}
           showFilters={showFilters}
           setShowFilters={setShowFilters}
-          cardStyle={cardStyle}
-          setCardStyle={setCardStyle}
+          viewMode={viewMode}
+          setViewMode={handleViewModeChange}
         />
         </div>
 
@@ -354,7 +349,6 @@ const PredictionsView = ({ handleEditPrediction }) => {
               onPredictionSelect={handlePredictionSelect}
               onEditClick={onEditClick}
               searchQuery={searchQuery}
-              cardStyle={cardStyle}
             />
           )}
         </div>

--- a/predictions-frontend/src/components/fixtures/FixtureFilters.jsx
+++ b/predictions-frontend/src/components/fixtures/FixtureFilters.jsx
@@ -7,7 +7,8 @@ import {
   ChevronDownIcon,
 } from "@radix-ui/react-icons";
 import { ThemeContext } from "../../context/ThemeContext";
-import { text, backgrounds } from "../../utils/themeUtils";
+import { text } from "../../utils/themeUtils";
+import ViewToggleBarHybrid from "../ui/ViewToggleBarHybrid";
 
 const FixtureFilters = ({
   activeFilter,
@@ -22,7 +23,9 @@ const FixtureFilters = ({
   setShowFilters,
   filterTeam,
   setFilterTeam,
-  fixtures = [], // Add fixtures prop to calculate counts
+  fixtures = [],
+  viewMode,
+  setViewMode,
 }) => {
   const { theme } = useContext(ThemeContext);
   const [showSearchOnMobile, setShowSearchOnMobile] = useState(false);
@@ -174,6 +177,11 @@ const FixtureFilters = ({
                     </span>
                   </button>
                 ))}
+              </div>
+
+              {/* View Selector */}
+              <div className="flex items-center gap-2 mb-3">
+                <ViewToggleBarHybrid viewMode={viewMode} setViewMode={setViewMode} />
               </div>
 
               {/* Advanced Filters Toggle */}
@@ -354,6 +362,11 @@ const FixtureFilters = ({
                 </span>
               </button>
             ))}
+          </div>
+
+          {/* View Selector */}
+          <div className="flex items-center">
+            <ViewToggleBarHybrid viewMode={viewMode} setViewMode={setViewMode} />
           </div>
         </div>
 

--- a/predictions-frontend/src/components/predictions/LeaguePredictionFilters.jsx
+++ b/predictions-frontend/src/components/predictions/LeaguePredictionFilters.jsx
@@ -7,8 +7,8 @@ import {
   ChevronDownIcon,
 } from "@radix-ui/react-icons";
 import { ThemeContext } from "../../context/ThemeContext";
-import { useUserPreferences } from "../../context/UserPreferencesContext";
 import { text } from "../../utils/themeUtils";
+import ViewToggleBarHybrid from "../ui/ViewToggleBarHybrid";
 
 const LeaguePredictionFilters = ({
   activeFilter,
@@ -23,14 +23,14 @@ const LeaguePredictionFilters = ({
   setSortBy,
   showFilters,
   setShowFilters,
-  cardStyle,
-  setCardStyle,
+  viewMode,
+  setViewMode,
+  views,
   predictions = [],
   currentGameweek = 1,
   maxGameweek = 38,
 }) => {
   const { theme } = useContext(ThemeContext);
-  const { updatePreference } = useUserPreferences();
   const [showSearchOnMobile, setShowSearchOnMobile] = useState(false);
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
 
@@ -189,49 +189,9 @@ const LeaguePredictionFilters = ({
                 ))}
               </div>
 
-              {/* Card Style Toggle */}
+              {/* View Selector */}
               <div className="flex items-center gap-2 mb-3">
-                <span className={`text-xs font-medium ${
-                  theme === 'dark' ? 'text-slate-400' : 'text-slate-500'
-                }`}>
-                  View:
-                </span>
-                <div className="flex rounded-lg overflow-hidden border border-slate-200 dark:border-slate-700">
-                  <button
-                    onClick={() => {
-                      setCardStyle('normal');
-                      updatePreference('cardStyle', 'normal');
-                    }}
-                    className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                      cardStyle === 'normal'
-                        ? theme === 'dark'
-                          ? 'bg-teal-600 text-white'
-                          : 'bg-teal-600 text-white'
-                        : theme === 'dark'
-                        ? 'bg-slate-800/50 text-slate-300 hover:bg-slate-700'
-                        : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-                    }`}
-                  >
-                    Normal
-                  </button>
-                  <button
-                    onClick={() => {
-                      setCardStyle('compact');
-                      updatePreference('cardStyle', 'compact');
-                    }}
-                    className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                      cardStyle === 'compact'
-                        ? theme === 'dark'
-                          ? 'bg-teal-600 text-white'
-                          : 'bg-teal-600 text-white'
-                        : theme === 'dark'
-                        ? 'bg-slate-800/50 text-slate-300 hover:bg-slate-700'
-                        : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-                    }`}
-                  >
-                    Compact
-                  </button>
-                </div>
+                <ViewToggleBarHybrid viewMode={viewMode} setViewMode={setViewMode} views={views} />
               </div>
 
               {/* Advanced Filters Toggle */}
@@ -412,49 +372,9 @@ const LeaguePredictionFilters = ({
               ))}
             </div>
 
-            {/* Card Style Toggle */}
-            <div className="flex items-center gap-2">
-              <span className={`text-xs font-medium ${
-                theme === 'dark' ? 'text-slate-400' : 'text-slate-500'
-              }`}>
-                View:
-              </span>
-              <div className="flex rounded-lg overflow-hidden border border-slate-200 dark:border-slate-700">
-                <button
-                  onClick={() => {
-                    setCardStyle('normal');
-                    updatePreference('cardStyle', 'normal');
-                  }}
-                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                    cardStyle === 'normal'
-                      ? theme === 'dark'
-                        ? 'bg-teal-600 text-white'
-                        : 'bg-teal-600 text-white'
-                      : theme === 'dark'
-                      ? 'bg-slate-800/50 text-slate-300 hover:bg-slate-700'
-                      : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-                  }`}
-                >
-                  Normal
-                </button>
-                <button
-                  onClick={() => {
-                    setCardStyle('compact');
-                    updatePreference('cardStyle', 'compact');
-                  }}
-                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                    cardStyle === 'compact'
-                      ? theme === 'dark'
-                        ? 'bg-teal-600 text-white'
-                        : 'bg-teal-600 text-white'
-                      : theme === 'dark'
-                      ? 'bg-slate-800/50 text-slate-300 hover:bg-slate-700'
-                      : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-                  }`}
-                >
-                  Compact
-                </button>
-              </div>
+            {/* View Selector */}
+            <div className="flex items-center">
+              <ViewToggleBarHybrid viewMode={viewMode} setViewMode={setViewMode} views={views} />
             </div>
           </div>
 

--- a/predictions-frontend/src/components/predictions/PredictionFilters.jsx
+++ b/predictions-frontend/src/components/predictions/PredictionFilters.jsx
@@ -7,8 +7,8 @@ import {
   ChevronDownIcon,
 } from "@radix-ui/react-icons";
 import { ThemeContext } from "../../context/ThemeContext";
-import { useUserPreferences } from "../../context/UserPreferencesContext";
-import { text, backgrounds } from "../../utils/themeUtils";
+import { text } from "../../utils/themeUtils";
+import ViewToggleBarHybrid from "../ui/ViewToggleBarHybrid";
 
 const PredictionFilters = ({
   predictions = [], // Accept predictions as prop
@@ -24,11 +24,10 @@ const PredictionFilters = ({
   setSortBy,
   showFilters,
   setShowFilters,
-  cardStyle,
-  setCardStyle,
+  viewMode,
+  setViewMode,
 }) => {
   const { theme } = useContext(ThemeContext);
-  const { preferences, updatePreference } = useUserPreferences();
   const [showSearchOnMobile, setShowSearchOnMobile] = useState(false);
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
 
@@ -181,49 +180,9 @@ const PredictionFilters = ({
                 ))}
               </div>
 
-              {/* Card Style Toggle */}
+              {/* View Selector */}
               <div className="flex items-center gap-2 mb-3">
-                <span className={`text-xs font-medium ${
-                  theme === 'dark' ? 'text-slate-400' : 'text-slate-500'
-                }`}>
-                  View:
-                </span>
-                <div className="flex rounded-lg overflow-hidden border border-slate-200 dark:border-slate-700">
-                  <button
-                    onClick={() => {
-                      setCardStyle('normal');
-                      updatePreference('cardStyle', 'normal');
-                    }}
-                    className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                      cardStyle === 'normal'
-                        ? theme === 'dark'
-                          ? 'bg-teal-600 text-white'
-                          : 'bg-teal-600 text-white'
-                        : theme === 'dark'
-                        ? 'bg-slate-800/50 text-slate-300 hover:bg-slate-700'
-                        : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-                    }`}
-                  >
-                    Normal
-                  </button>
-                  <button
-                    onClick={() => {
-                      setCardStyle('compact');
-                      updatePreference('cardStyle', 'compact');
-                    }}
-                    className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                      cardStyle === 'compact'
-                        ? theme === 'dark'
-                          ? 'bg-teal-600 text-white'
-                          : 'bg-teal-600 text-white'
-                        : theme === 'dark'
-                        ? 'bg-slate-800/50 text-slate-300 hover:bg-slate-700'
-                        : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-                    }`}
-                  >
-                    Compact
-                  </button>
-                </div>
+                <ViewToggleBarHybrid viewMode={viewMode} setViewMode={setViewMode} />
               </div>
 
               {/* Advanced Filters Toggle */}
@@ -406,49 +365,9 @@ const PredictionFilters = ({
             ))}
           </div>
 
-          {/* Card Style Toggle */}
-          <div className="flex items-center gap-2">
-            <span className={`text-xs font-medium ${
-              theme === 'dark' ? 'text-slate-400' : 'text-slate-500'
-            }`}>
-              View:
-            </span>
-            <div className="flex rounded-lg overflow-hidden border border-slate-200 dark:border-slate-700">
-              <button
-                onClick={() => {
-                  setCardStyle('normal');
-                  updatePreference('cardStyle', 'normal');
-                }}
-                className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                  cardStyle === 'normal'
-                    ? theme === 'dark'
-                      ? 'bg-teal-600 text-white'
-                      : 'bg-teal-600 text-white'
-                    : theme === 'dark'
-                    ? 'bg-slate-800/50 text-slate-300 hover:bg-slate-700'
-                    : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-                }`}
-              >
-                Normal
-              </button>
-              <button
-                onClick={() => {
-                  setCardStyle('compact');
-                  updatePreference('cardStyle', 'compact');
-                }}
-                className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                  cardStyle === 'compact'
-                    ? theme === 'dark'
-                      ? 'bg-teal-600 text-white'
-                      : 'bg-teal-600 text-white'
-                    : theme === 'dark'
-                    ? 'bg-slate-800/50 text-slate-300 hover:bg-slate-700'
-                    : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-                }`}
-              >
-                Compact
-              </button>
-            </div>
+          {/* View Selector */}
+          <div className="flex items-center">
+            <ViewToggleBarHybrid viewMode={viewMode} setViewMode={setViewMode} />
           </div>
         </div>
 


### PR DESCRIPTION
- Move ViewToggleBarHybrid from hero sections into filter headers on Predictions, Fixtures, and LeagueDetailView pages
- Replace Normal/Compact card style toggle with ViewToggleBarHybrid in PredictionFilters and LeaguePredictionFilters (both mobile and desktop)
- Add ViewToggleBarHybrid to FixtureFilters (had no toggle previously)
- Remove cardStyle state and props from PredictionsView, LeagueDetailView, and all filter/content components
- Clean up unused imports (ViewToggleBarHybrid from page components, useUserPreferences from filter components)

https://claude.ai/code/session_01Q5mipbpRiJNWo7sFEHch87