### PR TITLE
Fix status bar avatar field name mismatch

### DIFF
--- a/predictions-frontend/src/components/layout/StatusBar.jsx
+++ b/predictions-frontend/src/components/layout/StatusBar.jsx
@@ -99,9 +99,9 @@ export default function StatusBar({
               <div className="h-7 w-7 sm:h-12 sm:w-12 bg-slate-700/50 rounded-full mr-2 sm:mr-4 animate-pulse" />
             ) : (
               <div className="h-7 w-7 sm:h-12 sm:w-12 bg-indigo-600 rounded-full flex items-center justify-center text-white font-medium mr-2 sm:mr-4 text-sm sm:text-xl overflow-hidden">
-                {user?.profilePicture ? (
+                {user?.avatar ? (
                   <img
-                    src={user.profilePicture}
+                    src={user.avatar}
                     alt={userData.username}
                     className="w-full h-full object-cover"
                   />

--- a/predictions-frontend/src/components/layout/StatusBarOption1.jsx
+++ b/predictions-frontend/src/components/layout/StatusBarOption1.jsx
@@ -61,8 +61,8 @@ export default function StatusBarOption1({
               <div className="h-8 w-8 bg-slate-700/50 rounded-full animate-pulse flex-shrink-0" />
             ) : (
               <div className="h-8 w-8 bg-indigo-600 rounded-full flex items-center justify-center text-white font-medium text-sm flex-shrink-0 overflow-hidden">
-                {user?.profilePicture ? (
-                  <img src={user.profilePicture} alt={userData.username} className="w-full h-full object-cover" />
+                {user?.avatar ? (
+                  <img src={user.avatar} alt={userData.username} className="w-full h-full object-cover" />
                 ) : (
                   userData.username.substring(0, 1).toUpperCase()
                 )}

--- a/predictions-frontend/src/components/layout/StatusBarOption2.jsx
+++ b/predictions-frontend/src/components/layout/StatusBarOption2.jsx
@@ -69,8 +69,8 @@ export default function StatusBarOption2({
               <div className="h-8 w-8 bg-slate-700/50 rounded-full animate-pulse flex-shrink-0" />
             ) : (
               <div className="h-8 w-8 bg-indigo-600 rounded-full flex items-center justify-center text-white font-medium text-sm flex-shrink-0 overflow-hidden">
-                {user?.profilePicture ? (
-                  <img src={user.profilePicture} alt={userData.username} className="w-full h-full object-cover" />
+                {user?.avatar ? (
+                  <img src={user.avatar} alt={userData.username} className="w-full h-full object-cover" />
                 ) : (
                   userData.username.substring(0, 1).toUpperCase()
                 )}

--- a/predictions-frontend/src/components/layout/StatusBarOption3.jsx
+++ b/predictions-frontend/src/components/layout/StatusBarOption3.jsx
@@ -104,8 +104,8 @@ export default function StatusBarOption3({
             ) : (
               <>
                 <div className="h-6 w-6 lg:h-8 lg:w-8 bg-indigo-600 rounded-full flex items-center justify-center text-white font-medium text-xs lg:text-sm overflow-hidden">
-                  {user?.profilePicture ? (
-                    <img src={user.profilePicture} alt={userData.username} className="w-full h-full object-cover" />
+                  {user?.avatar ? (
+                    <img src={user.avatar} alt={userData.username} className="w-full h-full object-cover" />
                   ) : (
                     userData.username.substring(0, 1).toUpperCase()
                   )}


### PR DESCRIPTION
The DashboardEssentials.User DTO uses 'avatar', not 'profilePicture'. Changed user?.profilePicture to user?.avatar in all StatusBar variants.

https://claude.ai/code/session_01Q5mipbpRiJNWo7sFEHch87